### PR TITLE
New option: rearrange the metricname and value fields for easier parsing

### DIFF
--- a/lib/logstash/codecs/graphite.rb
+++ b/lib/logstash/codecs/graphite.rb
@@ -59,7 +59,6 @@ class LogStash::Codecs::Graphite < LogStash::Codecs::Base
       else
         yield LogStash::Event.new(name => value.to_f, LogStash::Event::TIMESTAMP => LogStash::Timestamp.at(time.to_i))
       end
-
       
     end # @lines.decode
   end # def decode

--- a/lib/logstash/codecs/graphite.rb
+++ b/lib/logstash/codecs/graphite.rb
@@ -40,6 +40,9 @@ class LogStash::Codecs::Graphite < LogStash::Codecs::Base
   # NOTE: If no metrics_format is defined the name of the metric will be used as fallback.
   config :metrics_format, :validate => :string, :default => DEFAULT_METRICS_FORMAT
 
+  config :as_key_value, :validate => :boolean, :default => false
+
+
 
   public
   def initialize(params={})
@@ -51,7 +54,14 @@ class LogStash::Codecs::Graphite < LogStash::Codecs::Base
   def decode(data)
     @lines.decode(data) do |event|
       name, value, time = event["message"].split(" ")
-      yield LogStash::Event.new(name => value.to_f, LogStash::Event::TIMESTAMP => LogStash::Timestamp.at(time.to_i))
+
+      if @as_key_value
+        yield LogStash::Event.new("key" => name, "value" => value.to_f, LogStash::Event::TIMESTAMP => LogStash::Timestamp.at(time.to_i))
+      else
+        yield LogStash::Event.new(name => value.to_f, LogStash::Event::TIMESTAMP => LogStash::Timestamp.at(time.to_i))
+      end
+
+      
     end # @lines.decode
   end # def decode
 

--- a/lib/logstash/codecs/graphite.rb
+++ b/lib/logstash/codecs/graphite.rb
@@ -43,8 +43,6 @@ class LogStash::Codecs::Graphite < LogStash::Codecs::Base
   # Instead of $metricname => $value, create the event fields as 'key' => $metricname, 'value' => $value
   config :as_key_value, :validate => :boolean, :default => false
 
-
-
   public
   def initialize(params={})
     super(params)

--- a/lib/logstash/codecs/graphite.rb
+++ b/lib/logstash/codecs/graphite.rb
@@ -40,6 +40,7 @@ class LogStash::Codecs::Graphite < LogStash::Codecs::Base
   # NOTE: If no metrics_format is defined the name of the metric will be used as fallback.
   config :metrics_format, :validate => :string, :default => DEFAULT_METRICS_FORMAT
 
+  # Instead of $metricname => $value, create the event fields as 'key' => $metricname, 'value' => $value
   config :as_key_value, :validate => :boolean, :default => false
 
 


### PR DESCRIPTION
Hi!
I had some problems with the way that the events were created. With the field name for the value defaulting to the metric name, it was impossible for me to adress the field containing the value in other filters down the processing road, since it would change with each event. I added an option (deactivated per default) to rearrange the data as follows:

Instead of $metricname => $value, create the event fields as 'key' => $metricname, 'value' => $value
so that later on you can apply other filters on the metricname using the "%{key}" syntax.

Thank you!
