### PR TITLE
Make sure the devutils rspec helper are loaded

### DIFF
--- a/spec/codecs/graphite_spec.rb
+++ b/spec/codecs/graphite_spec.rb
@@ -1,3 +1,4 @@
+require "logstash/devutils/rspec/spec_helper"
 require "logstash/codecs/graphite"
 require "logstash/event"
 require "insist"


### PR DESCRIPTION
Make sure the rspec helper are loaded before running anytest to make
sure the log4j helpers are correctly setup.

Fixes: #5

